### PR TITLE
Improve sanitization performance

### DIFF
--- a/benchmark/elm.json
+++ b/benchmark/elm.json
@@ -1,0 +1,30 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src",
+        "../src"
+    ],
+    "elm-version": "0.19.0",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.1",
+            "elm/core": "1.0.2",
+            "elm/html": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm-explorations/benchmark": "1.0.1"
+        },
+        "indirect": {
+            "BrianHicks/elm-trend": "2.1.2",
+            "Skinney/murmur3": "2.0.8",
+            "elm/json": "1.1.3",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "mdgriffith/style-elements": "5.0.1"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/benchmark/src/Main.elm
+++ b/benchmark/src/Main.elm
@@ -1,0 +1,32 @@
+module Main exposing (main)
+
+import Benchmark exposing (..)
+import Benchmark.Runner exposing (BenchmarkProgram, program)
+import Escape
+import Old.Escape
+
+
+main : BenchmarkProgram
+main =
+    program <|
+        describe "sanitization"
+            [ sanitizeBenchmark "input is all valid" valid
+            , sanitizeBenchmark "input has invalid stuff" invalid
+            ]
+
+
+sanitizeBenchmark : String -> String -> Benchmark
+sanitizeBenchmark description input =
+    Benchmark.compare description
+        "Old.Escape.sanitize"
+        (\_ -> Old.Escape.sanitize input)
+        "Escape.sanitize"
+        (\_ -> Escape.sanitize input)
+
+
+valid =
+    "crosstab-builder"
+
+
+invalid =
+    "  98 hel ___ žščř--ďťň  lo"

--- a/benchmark/src/Old/Escape.elm
+++ b/benchmark/src/Old/Escape.elm
@@ -1,0 +1,28 @@
+module Old.Escape exposing (sanitize, sanitizeNamespace)
+
+import Regex exposing (Regex)
+
+
+caseInsensitiveOption : Regex.Options
+caseInsensitiveOption =
+    { caseInsensitive = True
+    , multiline = False
+    }
+
+
+removeByRegex regex string =
+    Regex.fromStringWith caseInsensitiveOption regex
+        |> Maybe.map (\r -> String.toLower <| Regex.replace r (\_ -> "") string)
+        |> Maybe.withDefault string
+
+
+sanitizeNamespace : String -> String
+sanitizeNamespace str =
+    str
+        |> removeByRegex "[^a-z0-9\\-_]"
+        |> removeByRegex "^[\\d]+"
+
+
+sanitize : String -> String
+sanitize str =
+    removeByRegex "_{2,}|-{2,}" <| sanitizeNamespace str

--- a/src/WeakCss.elm
+++ b/src/WeakCss.elm
@@ -205,7 +205,7 @@ toString (ClassName classNamespace list) =
         [] ->
             classNamespace
 
-        head :: tail ->
+        _ :: _ ->
             classNamespace
                 ++ "__"
                 ++ List.foldr foldElement "" list

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -99,6 +99,10 @@ escapeTest =
             \() ->
                 Escape.sanitize " inva_lid st-ring__name--some-end "
                     |> Expect.equal "inva_lidst-ringnamesome-end"
+        , test "sanitize - complex example" <|
+            \() ->
+                Escape.sanitize "  98 hel ___ žščř--ďťň  lo"
+                    |> Expect.equal "hello"
         , test "CaPITAL to lowercase" <|
             \() ->
                 Escape.sanitize "CaPITAL"

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -4,6 +4,7 @@ module Tests exposing (escapeTest, inElement, namespaceClassTest, namespaced)
 
 import Escape
 import Expect
+import Fuzz
 import Html.Attributes exposing (class)
 import Test exposing (..)
 import WeakCss exposing (..)
@@ -115,4 +116,24 @@ escapeTest =
                 -dolor sit amet
                 """
                     |> Expect.equal "loremipsum-dolorsitamet"
+        , fuzz Fuzz.string "Sanitize random String" <|
+            \str ->
+                Escape.sanitize str
+                    |> (\sanitized -> hasOnlyValidCharacters sanitized && doesNotStartWithDigit sanitized)
+                    |> Expect.true "sanitized string should only contain valid characters"
         ]
+
+
+hasOnlyValidCharacters : String -> Bool
+hasOnlyValidCharacters =
+    String.all (\c -> Char.isDigit c || Char.isLower c || c == '_' || c == '-')
+
+
+doesNotStartWithDigit : String -> Bool
+doesNotStartWithDigit s =
+    case String.uncons s of
+        Nothing ->
+            True
+
+        Just ( firsChar, _ ) ->
+            not <| Char.isDigit firsChar


### PR DESCRIPTION
Previous sanitization implementation could have noticable impact on performance
when many elements with WeakCss classes were rendered on a page.

This is an attempt to improve performance by:
- merging multiple separate regexes into one via | (or)
- constructing "invalid stuff" regexes just once in advance

Benchmarks are showing ~7x speedup for valid inputs (they're valid most of the time)
and ~2x for inputs containing invalid characters. Results from chrome (firefox is showing similar numbers)

![Screenshot from 2019-09-25 07-41-52](https://user-images.githubusercontent.com/2716069/65573006-172f1600-df6a-11e9-9873-8a3df8dca85b.png)
